### PR TITLE
Linux: Support for IFF_NAPI and IFF_VNET_HDR (#114)

### DIFF
--- a/src/platform/linux/device.rs
+++ b/src/platform/linux/device.rs
@@ -13,8 +13,8 @@
 //  0. You just DO WHAT THE FUCK YOU WANT TO.
 
 use libc::{
-    self, c_char, c_short, ifreq, AF_INET, IFF_MULTI_QUEUE, IFF_NO_PI, IFF_RUNNING, IFF_TAP,
-    IFF_TUN, IFF_UP, IFNAMSIZ, O_RDWR, SOCK_DGRAM,
+    self, c_char, c_short, ifreq, AF_INET, IFF_MULTI_QUEUE, IFF_NAPI, IFF_NO_PI, IFF_RUNNING,
+    IFF_TAP, IFF_TUN, IFF_UP, IFF_VNET_HDR, IFNAMSIZ, O_RDWR, SOCK_DGRAM,
 };
 use std::{
     ffi::{CStr, CString},
@@ -95,9 +95,15 @@ impl Device {
 
             let iff_no_pi = IFF_NO_PI as c_short;
             let iff_multi_queue = IFF_MULTI_QUEUE as c_short;
+            let iff_napi = IFF_NAPI as c_short;
+            let iff_vnet_hdr = IFF_VNET_HDR as c_short;
             let packet_information = config.platform_config.packet_information;
+            let napi = config.platform_config.napi;
+            let vnet_hdr = config.platform_config.vnet_hdr;
             req.ifr_ifru.ifru_flags = device_type
                 | if packet_information { 0 } else { iff_no_pi }
+                | if napi { iff_napi } else { 0 }
+                | if vnet_hdr { iff_vnet_hdr } else { 0 }
                 | if queues_num > 1 { iff_multi_queue } else { 0 };
 
             let tun_fd = {

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -29,6 +29,12 @@ pub struct PlatformConfig {
     pub(crate) packet_information: bool,
     /// root privileges required or not
     pub(crate) ensure_root_privileges: bool,
+
+    /// Enable IFF_NAPI
+    pub(crate) napi: bool,
+
+    /// Enable IFF_VNET_HDR
+    pub(crate) vnet_hdr: bool,
 }
 
 /// `packet_information` is default to be `false` and `ensure_root_privileges` is default to be `true`.
@@ -37,6 +43,8 @@ impl Default for PlatformConfig {
         PlatformConfig {
             packet_information: false,
             ensure_root_privileges: true,
+            napi: false,
+            vnet_hdr: false,
         }
     }
 }
@@ -59,6 +67,18 @@ impl PlatformConfig {
     /// since some operations need it such as assigning IP/netmask/destination etc.
     pub fn ensure_root_privileges(&mut self, value: bool) -> &mut Self {
         self.ensure_root_privileges = value;
+        self
+    }
+
+    /// Enable / Disable IFF_NAPI flag.
+    pub fn napi(&mut self, value: bool) -> &mut Self {
+        self.napi = value;
+        self
+    }
+
+    /// Enable / Disable IFF_VNET_HDR flag.
+    pub fn vnet_hdr(&mut self, value: bool) -> &mut Self {
+        self.vnet_hdr = value;
         self
     }
 }


### PR DESCRIPTION
* README: Correct name of required linux kernel module

I think a search and replace caught this when the crate name changed to tun2.

* linux: Support for IFF_NAPI

* linux: Support for IFF_VNET_HDR

* minor changes

---------


(cherry picked from commit 89391f296c7b5302a63e274dbb065c56bc1e710f)